### PR TITLE
Add check_boundary_action_saturation probing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+.claude/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+SHELL=/bin/bash
+
+# Strict CPU isolation -- prevents tests from touching GPU when a live
+# experiment is running on this machine. CUDA_VISIBLE_DEVICES="" hides the
+# GPU from the CUDA driver entirely so CUDA init can't probe it.
+CPU_ENV := CUDA_VISIBLE_DEVICES="" JAX_PLATFORMS=cpu JAX_PLATFORM_NAME=cpu
+
+.PHONY: ci ci-tox ci-linting ci-coverage test help
+
+help:  ## Show this help message
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+# ---------------------------------------------------------------------------
+# Canonical local-CI -- runs tox which covers linting + tests + coverage,
+# matching what .github/workflows/poetry_build.yaml runs in CI.
+# Coverage gate per tox.ini ([testenv:coverage]) is --fail-under 75.
+# ---------------------------------------------------------------------------
+
+ci: ci-tox  ## Full local CI (matches .github/workflows/poetry_build.yaml -> tox)
+
+ci-tox:  ## Run the full tox envlist (py312, linting, coverage)
+	$(CPU_ENV) poetry run tox
+
+ci-linting:  ## Only the linting (pre-commit) env
+	poetry run tox -e linting
+
+ci-coverage:  ## Only the coverage env (--fail-under 75)
+	$(CPU_ENV) poetry run tox -e coverage
+
+# ---------------------------------------------------------------------------
+# Convenience: fast CPU-only pytest run without the coverage gate.
+# ---------------------------------------------------------------------------
+
+test:  ## Run pytest on CPU only (no coverage gate)
+	$(CPU_ENV) poetry run pytest --tb=short --disable-warnings

--- a/src/probing_environments/checks.py
+++ b/src/probing_environments/checks.py
@@ -598,3 +598,83 @@ def check_average_reward(
     assert value == pytest.approx(
         2 / 5, rel=0.5
     ), f"Expected value to be close to {value / env().TIME_LIMIT}, got {value=}"
+
+
+def check_boundary_action_saturation(
+    agent: AgentType,
+    init_agent: InitAgentType,
+    train_agent: Callable[[AgentType, float], AgentType],
+    get_action: Callable[..., np.ndarray],
+    budget: float = int(5e4),
+    learning_rate: Optional[float] = 1e-3,
+    num_envs: Optional[int] = 1,
+    gymnax: bool = False,
+    key: Optional[Any] = None,
+    threshold: float = 0.98,
+):
+    """Boundary-action saturation probe (catches log_prob recompute
+    instability for tanh-squashed Gaussian policies).
+
+    Uses ``AdvantagePolicyLossPolicyUpdateEnv``: 1-step env where
+    ``reward = action`` so the optimal policy is action = +1. For a
+    tanh-squashed Gaussian (SquashedNormal) actor, reaching action = +1
+    requires the policy mean to push to +∞ so that sampled pre-tanh
+    values land in the saturated region ``tanh(x) → ±1``. **This is
+    exactly the regime where on-policy agents (PPO, APO) that
+    recompute ``pi.log_prob(post_tanh_action)`` at update time hit
+    numerical instability**: distrax's ``Tanh.inverse_and_log_det``
+    calls ``arctanh(action)``, which is undefined at ``|action| = 1``
+    and numerically explosive nearby. The recomputed log_prob diverges
+    from the stored log_prob, the PPO ratio = ``exp(new − old)``
+    becomes huge or NaN, and the policy gets stuck around action ≈
+    0.95 instead of converging.
+
+    Contrast with the existing :func:`check_advantage_policy_continuous`,
+    which uses ``budget=2000`` and asserts ``action >= 0.90`` — too
+    permissive: a saturation-stalled PPO can pass that bar. This
+    stricter variant uses ``budget=50_000`` and asserts ``action >=
+    0.98``, which forces the policy through the saturation regime.
+
+    Fix on the agent side (Ajax PPO did this May 2026): store the
+    pre-tanh ``raw_action`` in the rollout buffer, and at update time
+    compute log_prob via ``base.log_prob(raw_action) -
+    forward_log_det_jacobian(raw_action)`` — never invert the tanh.
+    Brax PPO follows the same pattern.
+
+    Args:
+        threshold: Minimum acceptable action value. 0.98 by default
+            (corresponds to pre-tanh ``arctanh(0.98) ≈ 2.30`` — well
+            inside the unstable regime for distrax's inverse path).
+            Set to 0.95 for a softer check if needed.
+        budget: Training budget; 5e4 is enough for an unbroken PPO
+            to fully saturate on this trivial env, but starves a
+            saturation-stalled run.
+    """
+    if gymnax:
+        env = AdvantagePolicyLossPolicyUpdateEnv_continuous_gx
+    else:
+        env = AdvantagePolicyLossPolicyUpdateEnvContinuous
+    agent = init_agent(
+        agent=agent,
+        env=env,
+        run_name="check_boundary_action_saturation",
+        gamma=0.5,
+        learning_rate=learning_rate,
+        num_envs=num_envs,
+        budget=budget,
+    )
+    agent = train_agent(agent, budget)
+    if gymnax:
+        action = get_action(agent, np.array([1.0]), key)
+    else:
+        action = get_action(agent, np.array([1.0]))
+    err_msg = (
+        "Action did not saturate to the [-1, 1] boundary. This is the "
+        "diagnostic for ``pi.log_prob(post_tanh_action)`` recompute "
+        "instability in on-policy agents (PPO / APO). Fix: store the "
+        "pre-tanh raw_action in the rollout buffer and recompute "
+        "log_prob via base.log_prob(raw) - forward_log_det_jacobian(raw)."
+    )
+    assert action >= threshold, (
+        err_msg + f" Expected action >= {threshold}, got action={action}."
+    )

--- a/tests/test_sb3.py
+++ b/tests/test_sb3.py
@@ -21,6 +21,7 @@ from probing_environments.checks import (
     check_advantage_policy_continuous,
     check_average_reward,
     check_backprop_value_net,
+    check_boundary_action_saturation,
     check_loss_or_optimizer_value_net,
     check_reward_discounting,
 )
@@ -132,6 +133,28 @@ def test_check_advantage_policy_continuous():
         get_action,
         learning_rate=LEARNING_RATE,
         budget=BUDGET,
+    )
+
+
+def test_check_boundary_action_saturation():
+    """Test that check_boundary_action_saturation works on failproof sb3.
+
+    SB3 PPO uses an unbounded Gaussian + action-space clipping (not
+    SquashedNormal), so it doesn't hit the arctanh saturation
+    instability the check is designed to catch. The check still
+    asserts the agent learns to push action to the boundary (>=
+    threshold), which an unbroken SB3 PPO does easily on this trivial
+    1-step env. Larger budget than BUDGET (default 2e3) because the
+    threshold is 0.98 instead of 0.90 -- the looser
+    ``check_advantage_policy_continuous`` already passes at 2e3.
+    """
+    check_boundary_action_saturation(
+        AGENT,
+        init_agent,
+        train_agent,
+        get_action,
+        learning_rate=LEARNING_RATE,
+        budget=int(2e4),
     )
 
 


### PR DESCRIPTION
Catches log_prob recompute instability for tanh-squashed Gaussian policies. Uses ``AdvantagePolicyLossPolicyUpdateEnv`` (reward=action, optimal=+1) with budget=50_000 and threshold=0.98 — strict enough to force the policy through the saturation regime where distrax's ``Tanh.inverse_and_log_det`` calls ``arctanh(action)`` and becomes numerically explosive.

This is the diagnostic for the m4 audit (May 2026) bug in Ajax PPO: on-policy agents that store the post-tanh action and recompute log_prob via ``pi.log_prob(action)`` get stuck around action ≈ 0.95 because the recomputed log_prob diverges from the stored log_prob and the PPO ratio = exp(new-old) blows up.

Fix on the agent side (Ajax PPO + Brax PPO pattern): store the pre-tanh raw_action and recompute via base.log_prob(raw) - forward_log_det_jacobian(raw) — never invert the tanh. Test stays agnostic to the fix; it just checks that the agent actually saturates.

Contrast with check_advantage_policy_continuous (existing): budget= 2000 + threshold=0.90 is too permissive; a saturation-stalled PPO can pass it. This stricter probe would have caught m4 earlier.

Also: add .claude/ to .gitignore (Claude Code editor settings).